### PR TITLE
Fixing issue #2  related to usage of six.moves.range

### DIFF
--- a/runsnakerun/listviews.py
+++ b/runsnakerun/listviews.py
@@ -120,7 +120,7 @@ class DataView(wx.ListCtrl):
         """Create/recreate our column definitions from current self.columns"""
         self.SetItemCount(0)
         # clear any current columns...
-        for i in range(self.GetColumnCount())[::-1]:
+        for i in range(self.GetColumnCount()-1, -1, -1):
             self.DeleteColumn(i)
         # now create
         for i, column in enumerate(self.columns):


### PR DESCRIPTION
https://six.readthedocs.io/#module-six.moves (**Renamed modules and attributes compatibility**)
`range` in `six.moves` refers to [xrange](https://docs.python.org/2/library/functions.html#xrange) in python 2 and [range](https://docs.python.org/3.3/library/stdtypes.html?highlight=range#ranges) in python 3

In my opinion, `range(self.GetColumnCount())[::-1]`  is not a proper usage.
Though this works in python 3 but it crashes in python 2.

https://www.geeksforgeeks.org/range-vs-xrange-python/
This webpage explains the use of xrange.
> ### Operations usage
> As range() returns the list, all the operations that can be applied on the list can be used on it. On the other hand, as xrange() returns the xrange object, operations associated to list cannot be applied on them, hence a disadvantage.

```
import six.moves as sm

for i in sm.xrange(1)[::-1]:
	print("test i: {}".format(i))
```

In python 2, it throws the error:
`TypeError: sequence index must be integer, not 'slice'`


